### PR TITLE
Improve API Structure,  and Schema Handling

### DIFF
--- a/API/Authorization.ts
+++ b/API/Authorization.ts
@@ -1,6 +1,6 @@
 import { APIRequestContext, APIResponse,expect } from '@playwright/test';
-import { verifyResponseSchema, verifyResponseCode, getEnv } from '../Helper/Tools';
-import { buildSchema, makeRequest, Messages } from '../Helper/API_Helper';
+import {  getEnv } from '../Helper/Tools';
+import { buildSchema, makeRequest, Messages, verifyResponseSchema, verifyResponseCode } from '../Helper/API_Helper';
 import { z } from 'zod';
 import { Status, APIEndPoints } from '../Helper/API_Helper';
 

--- a/API/Authorization.ts
+++ b/API/Authorization.ts
@@ -1,12 +1,20 @@
 import { APIRequestContext, APIResponse,expect } from '@playwright/test';
-import { verifyResponseSchema, verifyResponseCode, makeRequest, getEnv } from '../Helper/Tools';
+import { verifyResponseSchema, verifyResponseCode, getEnv } from '../Helper/Tools';
+import { buildSchema, makeRequest, Messages } from '../Helper/API_Helper';
 import { z } from 'zod';
 import { Status, APIEndPoints } from '../Helper/API_Helper';
 
 export class AuthorizationAPI{
-    readonly request: APIRequestContext;
+    private readonly request: APIRequestContext;
 
-    readonly requests: {
+    private readonly schemas: {
+        LoginSuccessSchema: z.ZodTypeAny;
+        DeleteAccountSuccessSchema: z.ZodTypeAny;
+        UserDetailSuccessSchema: () => Promise<z.ZodTypeAny>;
+        CreateAccountSchema: (expectedCode: number, expectedMessage: string) => Promise<z.ZodTypeAny>;
+   };
+
+    private readonly requests: {
         POST_verifyLogin: (method: string, email: string, password: string ) => Promise<APIResponse>;
         POST_createAccount: (method: string, name: string, email: string , password: string , title: string , birth_date: string , birth_month: string , birth_year: string , firstname: string , lastname: string , company: string , address1: string , address2: string , country: string , zipcode: string , state: string , city: string , mobile_number: string ) => Promise<APIResponse>;
         POST_deleteAccount: (method: string, email: string, password: string ) => Promise<APIResponse>;
@@ -21,7 +29,7 @@ export class AuthorizationAPI{
     };
      
     readonly assertions: {
-        verifyLoginResponseSchema: (response: APIResponse, expectedCode: number, expectedMessage: string) => Promise<void>;
+        verifyLoginResponseSchema: (response: APIResponse, expectedCode: number, expectedMessage: string, successSchema: z.ZodTypeAny) => Promise<void>;
         verifyCreateAccountResponseSchema: (response: APIResponse, expectedCode: number, expectedMessage: string) => Promise<void>;
         verifyUserDetailResponseSchema: (response: APIResponse, expectedCode: number, expectedMessage: string ) => Promise<void>;
     };
@@ -29,16 +37,65 @@ export class AuthorizationAPI{
     constructor(request: APIRequestContext){
         this.request = request;
 
+        this.schemas = {
+            LoginSuccessSchema: z.object({
+              responseCode: z.literal(Status.success),
+              message: z.literal(Messages.userFoundMessage),
+            }),
+
+            DeleteAccountSuccessSchema: z.object({
+              responseCode: z.literal(Status.success),
+              message: z.literal(Messages.userDeletedMessage),
+            }),
+
+            UserDetailSuccessSchema: async () => {
+                return z.object({
+                  responseCode: z.literal(Status.success),
+                  user: z.object({
+                        id: z.number(),
+                        name: z.literal(await getEnv("VALID_LOGIN_NAME_FIRST")),
+                        email: z.literal(await getEnv("VALID_LOGIN_EMAIL")),
+                        title: z.string(),
+                        birth_day: z.string(),
+                        birth_month: z.string(),
+                        birth_year: z.string(),
+                        first_name: z.string(),
+                        last_name: z.string(),
+                        company: z.string(),
+                        address1: z.string(),
+                        address2: z.string(),
+                        country: z.string(),
+                        state: z.string(),
+                        city: z.string(),
+                        zipcode: z.string()
+                    })
+                });
+            },
+
+            CreateAccountSchema: async (expectedCode: number, expectedMessage: string) => {
+                let schema;
+                if(expectedCode !== 405){
+                    schema = z.object({
+                      responseCode: z.literal(expectedCode),
+                      message: z.literal(expectedMessage),
+                    });
+                }else{
+                    schema = z.object({
+                      detail: z.literal(expectedMessage),
+                    });
+                }
+                return schema;
+            },
+        }
+
         this.requests = {
             POST_verifyLogin: async (method, email: string , password: string ) => {
-                expect(method).not.toBe(undefined);
                 const form: Record<string, string> = {};
                 if (email !== undefined) form.email = email;
                 if (password !== undefined) form.password = password;
                 return makeRequest(this.request ,APIEndPoints.verifyLogin,method, form);
             },
             POST_createAccount: async  (method, name: string , email: string , password: string , title: string , birth_date: string , birth_month: string , birth_year: string , firstname: string , lastname: string , company: string , address1: string , address2: string , country: string , zipcode: string , state: string , city: string , mobile_number: string ) => {
-                expect(method).not.toBe(undefined);
                 const form: Record<string, string> = {};
                 if (name !== undefined) form.name = name;
                 if (email !== undefined) form.email = email;
@@ -60,14 +117,12 @@ export class AuthorizationAPI{
                 return makeRequest(this.request, APIEndPoints.createAccount, method, form);
             },
             POST_deleteAccount: async  (method, email: string , password: string ) => {
-                expect(method).not.toBe(undefined);
                 const form: Record<string, string> = {};
                 if (email !== undefined) form.email = email;
                 if (password !== undefined) form.password = password;
                 return makeRequest(this.request ,APIEndPoints.deleteAccount, method, form);
             },
             GET_getUserDetailByEmail: async  (method, email: string ) => {
-                expect(method).not.toBe(undefined);
                 const form: Record<string, string> = {};
                 if (email !== undefined) form.email = email;
                 return makeRequest(this.request , APIEndPoints.getUserDetailByEmail, method, form); 
@@ -75,63 +130,19 @@ export class AuthorizationAPI{
         };
 
         this.assertions = {
-            verifyLoginResponseSchema: async (response: APIResponse, expectedCode: number, expectedMessage: string) => {
-                const schema = z.object({
-                  responseCode: z.literal(expectedCode),
-                  message: z.literal(expectedMessage),
-                });
+            verifyLoginResponseSchema: async (response: APIResponse, expectedCode: number, expectedMessage: string, successSchema: z.ZodTypeAny) => {
+                const schema = await buildSchema(successSchema, expectedCode, expectedMessage);
                 await verifyResponseSchema(response,schema);
             },
 
             verifyCreateAccountResponseSchema: async (response: APIResponse, expectedCode: number, expectedMessage: string) => {
-                let schema;
-                if(expectedCode !== 405){
-                    schema = z.object({
-                      responseCode: z.literal(expectedCode),
-                      message: z.literal(expectedMessage),
-                    });
-                }else{
-                    schema = z.object({
-                      detail: z.literal(expectedMessage),
-                    });
-                }
+                let schema = await this.schemas.CreateAccountSchema(expectedCode, expectedMessage);
                 await verifyResponseSchema(response,schema);
             },
 
             verifyUserDetailResponseSchema: async (response: APIResponse, expectedCode: number, expectedMessage: string ) => {
                 const responseBody = await response.json();
-                let schema;
-                if(responseBody.responseCode !== Status.success)
-                {
-                    schema = z.object({
-                      responseCode: z.literal(expectedCode),
-                      message: z.literal(expectedMessage),
-                    });
-                }
-                else{
-                    schema = z.object({
-                      responseCode: z.literal(expectedCode),
-                      user: z.object({
-                            id: z.number(),
-                            name: z.literal(await getEnv("VALID_LOGIN_NAME_FIRST")),
-                            email: z.literal(await getEnv("VALID_LOGIN_EMAIL")),
-                            title: z.string(),
-                            birth_day: z.string(),
-                            birth_month: z.string(),
-                            birth_year: z.string(),
-                            first_name: z.string(),
-                            last_name: z.string(),
-                            company: z.string(),
-                            address1: z.string(),
-                            address2: z.string(),
-                            country: z.string(),
-                            state: z.string(),
-                            city: z.string(),
-                            zipcode: z.string()
-                        })
-                    });
-                }
-
+                let schema = await buildSchema(await this.schemas.UserDetailSuccessSchema(), expectedCode, expectedMessage);
                 await verifyResponseSchema(response,schema);
             },
         };
@@ -164,13 +175,13 @@ export class AuthorizationAPI{
           deleteAccount: async (method, email, password, ExpectedCode, ExpectedMessage) => {
             const response = await this.requests.POST_deleteAccount(method,email,password);
             await verifyResponseCode(response,ExpectedCode);
-            await this.assertions.verifyLoginResponseSchema(response,ExpectedCode,ExpectedMessage);
+            await this.assertions.verifyLoginResponseSchema(response,ExpectedCode,ExpectedMessage,this.schemas.DeleteAccountSuccessSchema);
           },
 
           verifyLogin: async (method, expectedCode, expectedMessage, email, password) => {
             const response = await this.requests.POST_verifyLogin(method,email,password);
             await verifyResponseCode(response,expectedCode);
-            await this.assertions.verifyLoginResponseSchema(response,expectedCode,expectedMessage);
+            await this.assertions.verifyLoginResponseSchema(response,expectedCode,expectedMessage,this.schemas.LoginSuccessSchema);
           },
 
           getUserDetailByEmail: async (method, email, ExpectedCode, ExpectedMessage ) => {

--- a/API/Authorization.ts
+++ b/API/Authorization.ts
@@ -4,158 +4,180 @@ import { z } from 'zod';
 import { Status, APIEndPoints } from '../Helper/API_Helper';
 
 export class AuthorizationAPI{
-    readonly Title = {Mr: "Mr", Mrs: "Mrs", Miss: "Miss"};
     readonly request: APIRequestContext;
-    readonly POST_verifyLogin: (method: string, email: string, password: string ) => Promise<APIResponse>;
-    readonly POST_createAccount: (method: string, name: string, email: string , password: string , title: string , birth_date: string , birth_month: string , birth_year: string , firstname: string , lastname: string , company: string , address1: string , address2: string , country: string , zipcode: string , state: string , city: string , mobile_number: string ) => Promise<APIResponse>;
-    readonly POST_deleteAccount: (method: string, email: string, password: string ) => Promise<APIResponse>;
-    readonly GET_getUserDetailByEmail: (method: string, email: string) => Promise<APIResponse>;
+
+    readonly requests: {
+        POST_verifyLogin: (method: string, email: string, password: string ) => Promise<APIResponse>;
+        POST_createAccount: (method: string, name: string, email: string , password: string , title: string , birth_date: string , birth_month: string , birth_year: string , firstname: string , lastname: string , company: string , address1: string , address2: string , country: string , zipcode: string , state: string , city: string , mobile_number: string ) => Promise<APIResponse>;
+        POST_deleteAccount: (method: string, email: string, password: string ) => Promise<APIResponse>;
+        GET_getUserDetailByEmail: (method: string, email: string) => Promise<APIResponse>;
+    };
+
+    readonly methods: {
+        createAccount: (method: string, ExpectedCode: number, ExpectedMessage:string , name: string , email: string , password: string , title: string , birth_date: string , birth_month: string , birth_year: string , firstname: string , lastname: string , company: string , address1: string , address2: string , country: string , zipcode: string , state: string , city: string , mobile_number: string ) => Promise<void>;
+        deleteAccount: (method: string, email: string, password: string, ExpectedCode: number, ExpectedMessage: string) => Promise<void>;
+        verifyLogin: (method: string, expectedCode: number, expectedMessage: string, email: string, password: string) => Promise<void>;
+        getUserDetailByEmail: (method: string, email: string, ExpectedCode: number, ExpectedMessage: string ) => Promise<void>;
+    };
+     
+    readonly assertions: {
+        verifyLoginResponseSchema: (response: APIResponse, expectedCode: number, expectedMessage: string) => Promise<void>;
+        verifyCreateAccountResponseSchema: (response: APIResponse, expectedCode: number, expectedMessage: string) => Promise<void>;
+        verifyUserDetailResponseSchema: (response: APIResponse, expectedCode: number, expectedMessage: string ) => Promise<void>;
+    };
+
     constructor(request: APIRequestContext){
         this.request = request;
-        this.POST_verifyLogin = (method, email: string , password: string ) => {
-            expect(method).not.toBe(undefined);
-            const form: Record<string, string> = {};
-            if (email !== undefined) form.email = email;
-            if (password !== undefined) form.password = password;
-            return makeRequest(this.request ,APIEndPoints.verifyLogin,method, form);
+
+        this.requests = {
+            POST_verifyLogin: async (method, email: string , password: string ) => {
+                expect(method).not.toBe(undefined);
+                const form: Record<string, string> = {};
+                if (email !== undefined) form.email = email;
+                if (password !== undefined) form.password = password;
+                return makeRequest(this.request ,APIEndPoints.verifyLogin,method, form);
+            },
+            POST_createAccount: async  (method, name: string , email: string , password: string , title: string , birth_date: string , birth_month: string , birth_year: string , firstname: string , lastname: string , company: string , address1: string , address2: string , country: string , zipcode: string , state: string , city: string , mobile_number: string ) => {
+                expect(method).not.toBe(undefined);
+                const form: Record<string, string> = {};
+                if (name !== undefined) form.name = name;
+                if (email !== undefined) form.email = email;
+                if (password !== undefined) form.password = password;
+                if (title !== undefined) form.title = title;
+                if (birth_date !== undefined) form.birth_date = birth_date;
+                if (birth_month !== undefined) form.birth_month = birth_month;
+                if (birth_year !== undefined) form.birth_year = birth_year;
+                if (firstname !== undefined) form.firstname = firstname;
+                if (lastname !== undefined) form.lastname = lastname;
+                if (company !== undefined) form.company = company;
+                if (address1 !== undefined) form.address1 = address1;
+                if (address2 !== undefined) form.address2 = address2;
+                if (country !== undefined) form.country = country;
+                if (zipcode !== undefined) form.zipcode = zipcode;
+                if (state !== undefined) form.state = state;
+                if (city !== undefined) form.city = city;
+                if (mobile_number !== undefined) form.mobile_number = mobile_number;
+                return makeRequest(this.request, APIEndPoints.createAccount, method, form);
+            },
+            POST_deleteAccount: async  (method, email: string , password: string ) => {
+                expect(method).not.toBe(undefined);
+                const form: Record<string, string> = {};
+                if (email !== undefined) form.email = email;
+                if (password !== undefined) form.password = password;
+                return makeRequest(this.request ,APIEndPoints.deleteAccount, method, form);
+            },
+            GET_getUserDetailByEmail: async  (method, email: string ) => {
+                expect(method).not.toBe(undefined);
+                const form: Record<string, string> = {};
+                if (email !== undefined) form.email = email;
+                return makeRequest(this.request , APIEndPoints.getUserDetailByEmail, method, form); 
+            }
         };
-        this.POST_createAccount = (method, name: string , email: string , password: string , title: string , birth_date: string , birth_month: string , birth_year: string , firstname: string , lastname: string , company: string , address1: string , address2: string , country: string , zipcode: string , state: string , city: string , mobile_number: string ) => {
-            expect(method).not.toBe(undefined);
-            const form: Record<string, string> = {};
-            if (name !== undefined) form.name = name;
-            if (email !== undefined) form.email = email;
-            if (password !== undefined) form.password = password;
-            if (title !== undefined) form.title = title;
-            if (birth_date !== undefined) form.birth_date = birth_date;
-            if (birth_month !== undefined) form.birth_month = birth_month;
-            if (birth_year !== undefined) form.birth_year = birth_year;
-            if (firstname !== undefined) form.firstname = firstname;
-            if (lastname !== undefined) form.lastname = lastname;
-            if (company !== undefined) form.company = company;
-            if (address1 !== undefined) form.address1 = address1;
-            if (address2 !== undefined) form.address2 = address2;
-            if (country !== undefined) form.country = country;
-            if (zipcode !== undefined) form.zipcode = zipcode;
-            if (state !== undefined) form.state = state;
-            if (city !== undefined) form.city = city;
-            if (mobile_number !== undefined) form.mobile_number = mobile_number;
-            return makeRequest(this.request, APIEndPoints.createAccount, method, form);
+
+        this.assertions = {
+            verifyLoginResponseSchema: async (response: APIResponse, expectedCode: number, expectedMessage: string) => {
+                const schema = z.object({
+                  responseCode: z.literal(expectedCode),
+                  message: z.literal(expectedMessage),
+                });
+                await verifyResponseSchema(response,schema);
+            },
+
+            verifyCreateAccountResponseSchema: async (response: APIResponse, expectedCode: number, expectedMessage: string) => {
+                let schema;
+                if(expectedCode !== 405){
+                    schema = z.object({
+                      responseCode: z.literal(expectedCode),
+                      message: z.literal(expectedMessage),
+                    });
+                }else{
+                    schema = z.object({
+                      detail: z.literal(expectedMessage),
+                    });
+                }
+                await verifyResponseSchema(response,schema);
+            },
+
+            verifyUserDetailResponseSchema: async (response: APIResponse, expectedCode: number, expectedMessage: string ) => {
+                const responseBody = await response.json();
+                let schema;
+                if(responseBody.responseCode !== Status.success)
+                {
+                    schema = z.object({
+                      responseCode: z.literal(expectedCode),
+                      message: z.literal(expectedMessage),
+                    });
+                }
+                else{
+                    schema = z.object({
+                      responseCode: z.literal(expectedCode),
+                      user: z.object({
+                            id: z.number(),
+                            name: z.literal(await getEnv("VALID_LOGIN_NAME_FIRST")),
+                            email: z.literal(await getEnv("VALID_LOGIN_EMAIL")),
+                            title: z.string(),
+                            birth_day: z.string(),
+                            birth_month: z.string(),
+                            birth_year: z.string(),
+                            first_name: z.string(),
+                            last_name: z.string(),
+                            company: z.string(),
+                            address1: z.string(),
+                            address2: z.string(),
+                            country: z.string(),
+                            state: z.string(),
+                            city: z.string(),
+                            zipcode: z.string()
+                        })
+                    });
+                }
+
+                await verifyResponseSchema(response,schema);
+            },
         };
-        this.POST_deleteAccount = (method, email: string , password: string ) => {
-            expect(method).not.toBe(undefined);
-            const form: Record<string, string> = {};
-            if (email !== undefined) form.email = email;
-            if (password !== undefined) form.password = password;
-            return makeRequest(this.request ,APIEndPoints.deleteAccount, method, form);
+
+        this.methods = {
+          createAccount: async (method, ExpectedCode, ExpectedMessage , name , email , password , title , birth_date , birth_month , birth_year , firstname , lastname , company , address1 , address2 , country , zipcode , state , city , mobile_number ) => {
+            const response = await this.requests.POST_createAccount(
+                method,
+                name,
+                email,
+                password,
+                title,
+                birth_date,
+                birth_month,
+                birth_year,
+                firstname,
+                lastname,
+                company,
+                address1,
+                address2,
+                country,
+                zipcode,
+                state,
+                city,
+                mobile_number
+            );
+            await expect((await response).ok()).toBe((ExpectedMessage.includes("not allowed.") ? false : true));
+            await this.assertions.verifyCreateAccountResponseSchema(response,ExpectedCode,ExpectedMessage);
+          },
+          deleteAccount: async (method, email, password, ExpectedCode, ExpectedMessage) => {
+            const response = await this.requests.POST_deleteAccount(method,email,password);
+            await verifyResponseCode(response,ExpectedCode);
+            await this.assertions.verifyLoginResponseSchema(response,ExpectedCode,ExpectedMessage);
+          },
+
+          verifyLogin: async (method, expectedCode, expectedMessage, email, password) => {
+            const response = await this.requests.POST_verifyLogin(method,email,password);
+            await verifyResponseCode(response,expectedCode);
+            await this.assertions.verifyLoginResponseSchema(response,expectedCode,expectedMessage);
+          },
+
+          getUserDetailByEmail: async (method, email, ExpectedCode, ExpectedMessage ) => {
+            const response = await this.requests.GET_getUserDetailByEmail(method,email);
+            await verifyResponseCode(response,ExpectedCode);
+            await this.assertions.verifyUserDetailResponseSchema(response,ExpectedCode,ExpectedMessage);
+          },
         };
-        this.GET_getUserDetailByEmail = (method, email: string ) => {
-            expect(method).not.toBe(undefined);
-            const form: Record<string, string> = {};
-            if (email !== undefined) form.email = email;
-            return makeRequest(this.request , APIEndPoints.getUserDetailByEmail, method, form); 
-        };
-    }
-
-    async verifyLoginAPISchema(response: APIResponse, expectedCode: number, expectedMessage: string){
-        const schema = z.object({
-          responseCode: z.literal(expectedCode),
-          message: z.literal(expectedMessage),
-        });
-        await verifyResponseSchema(response,schema);
-    }
-
-    async verifyCreateACcountAPISchema(response: APIResponse, expectedCode: number, expectedMessage: string){
-        let schema;
-        if(expectedCode !== 405){
-            schema = z.object({
-              responseCode: z.literal(expectedCode),
-              message: z.literal(expectedMessage),
-            });
-        }else{
-            schema = z.object({
-              detail: z.literal(expectedMessage),
-            });
-        }
-        await verifyResponseSchema(response,schema);
-    }
-
-    async createAccount(method: string, ExpectedCode: number, ExpectedMessage:string , name: string , email: string , password: string , title: string , birth_date: string , birth_month: string , birth_year: string , firstname: string , lastname: string , company: string , address1: string , address2: string , country: string , zipcode: string , state: string , city: string , mobile_number: string ){
-        const response = await this.POST_createAccount(
-            method,
-            name,
-            email,
-            password,
-            title,
-            birth_date,
-            birth_month,
-            birth_year,
-            firstname,
-            lastname,
-            company,
-            address1,
-            address2,
-            country,
-            zipcode,
-            state,
-            city,
-            mobile_number
-        );
-        await expect((await response).ok()).toBe((ExpectedMessage.includes("not allowed.") ? false : true));
-        await this.verifyCreateACcountAPISchema(response,ExpectedCode,ExpectedMessage);
-    }
-
-    async deleteAccount(method: string, email: string, password: string, ExpectedCode: number, ExpectedMessage: string){
-        const response = await this.POST_deleteAccount(method,email,password);
-        await verifyResponseCode(response,ExpectedCode);
-        await this.verifyLoginAPISchema(response,ExpectedCode,ExpectedMessage);
-    }
-
-    async verifyUserDetailSchema(response: APIResponse, expectedCode: number, expectedMessage: string ){
-        const responseBody = await response.json();
-        let schema;
-        if(responseBody.responseCode !== Status.success)
-        {
-            schema = z.object({
-              responseCode: z.literal(expectedCode),
-              message: z.literal(expectedMessage),
-            });
-        }
-        else{
-            schema = z.object({
-              responseCode: z.literal(expectedCode),
-              user: z.object({
-                    id: z.number(),
-                    name: z.literal(await getEnv("VALID_LOGIN_NAME_FIRST")),
-                    email: z.literal(await getEnv("VALID_LOGIN_EMAIL")),
-                    title: z.string(),
-                    birth_day: z.string(),
-                    birth_month: z.string(),
-                    birth_year: z.string(),
-                    first_name: z.string(),
-                    last_name: z.string(),
-                    company: z.string(),
-                    address1: z.string(),
-                    address2: z.string(),
-                    country: z.string(),
-                    state: z.string(),
-                    city: z.string(),
-                    zipcode: z.string()
-                })
-            });
-        }
-        
-        await verifyResponseSchema(response,schema);
-    }
-
-    async verifyLogin(method: string, expectedCode: number, expectedMessage: string, email: string, password: string){
-        const response = await this.POST_verifyLogin(method,email,password);
-        await verifyResponseCode(response,expectedCode);
-        await this.verifyLoginAPISchema(response,expectedCode,expectedMessage);
-    }
-
-    async getUserDetailByEmail(method: string, email: string, ExpectedCode: number, ExpectedMessage: string ){
-        const response = await this.GET_getUserDetailByEmail(method,email);
-        await verifyResponseCode(response,ExpectedCode);
-        await this.verifyUserDetailSchema(response,ExpectedCode,ExpectedMessage);
     }
 }

--- a/API/Products.ts
+++ b/API/Products.ts
@@ -5,74 +5,87 @@ import { APIEndPoints, Status } from '../Helper/API_Helper';
 
 export class ProductsAPI{
     readonly request: APIRequestContext;
-    readonly GET_brandsList: (method: string) => Promise<APIResponse>;
-    readonly POST_searchProduct: (method: string, productName: string) => Promise<APIResponse>;
+
+    readonly requests: {
+        GET_brandsList: (method: string) => Promise<APIResponse>;
+        POST_searchProduct: (method: string, productName: string) => Promise<APIResponse>;
+    };
+
+    readonly methods: {
+        brandsList: (method: string, ExpectedCode: number, ExpectedMessage?: string) => Promise<void>;
+        searchProduct: (method: string, ExpectedCode: number, ExpectedMessage: string, productName: string) => Promise<void>;
+    }
 
     constructor(request: APIRequestContext){
         this.request = request;
-        this.GET_brandsList = (method) => {
-            expect(method).not.toBe(undefined);
-            return makeRequest(this.request , APIEndPoints.brandList, method);
-        };
-        this.POST_searchProduct = (method,productName: string) => {
-            expect(method).not.toBe(undefined);
-            const form: Record<string, string> = {};
-            if (productName !== "") form.search_product = productName;
-            return makeRequest(this.request, APIEndPoints.searchProduct, method, form);
-        };
-    }
 
-    async brandsList(method: string, ExpectedCode: number, ExpectedMessage: string = ""){
-        let schema;
-        if(ExpectedCode !== Status.success){
-            schema = z.object({
-                responseCode: z.literal(ExpectedCode),
-                message: z.literal(ExpectedMessage)
-            });
-        }else{
-            schema = z.object({
-                responseCode: z.literal(ExpectedCode),
-                brands: z.array(
-                    z.object({
-                        id: z.number(),
-                        brand: z.string(),
-                    })
-                ).nonempty("brands array must contain at least one item")
-            });
-        } 
-        const response = await this.GET_brandsList(method);
-        await verifyResponseCode(response,ExpectedCode);
-        await verifyResponseSchema(response,schema);
-    }
+        this.requests = {
+            GET_brandsList: async  (method) => {
+                expect(method).not.toBe(undefined);
+                return makeRequest(this.request , APIEndPoints.brandList, method);
+            },
+            POST_searchProduct: async  (method,productName: string) => {
+                expect(method).not.toBe(undefined);
+                const form: Record<string, string> = {};
+                if (productName !== "") form.search_product = productName;
+                return makeRequest(this.request, APIEndPoints.searchProduct, method, form);
+            },
+        };
 
-    async searchProduct(method: string, ExpectedCode: number, ExpectedMessage: string, productName: string){
-        let schema;
-        if(ExpectedCode !== Status.success){
-            schema = z.object({
-                responseCode: z.literal(ExpectedCode),
-                message: z.literal(ExpectedMessage)
-            });
-        }else{
-            schema = z.object({
-                responseCode: z.literal(ExpectedCode),
-                products: z.array(
-                    z.object({
-                        id: z.number(),
-                        name: z.string(),
-                        price: z.string(),
-                        brand: z.string(),
-                        category: z.object({
-                            usertype: z.object({
-                                usertype: z.string()
-                            }),
-                            category: z.string()
-                        })
-                    })
-                )
-            });
-        } 
-        const response = await this.POST_searchProduct(method,productName);
-        await verifyResponseCode(response,ExpectedCode);
-        await verifyResponseSchema(response,schema);
+        this.methods = {
+            brandsList: async (method, ExpectedCode, ExpectedMessage="") => {
+                let schema;
+                if(ExpectedCode !== Status.success){
+                    schema = z.object({
+                        responseCode: z.literal(ExpectedCode),
+                        message: z.literal(ExpectedMessage)
+                    });
+                }else{
+                    schema = z.object({
+                        responseCode: z.literal(ExpectedCode),
+                        brands: z.array(
+                            z.object({
+                                id: z.number(),
+                                brand: z.string(),
+                            })
+                        ).nonempty("brands array must contain at least one item")
+                    });
+                } 
+                const response = await this.requests.GET_brandsList(method);
+                await verifyResponseCode(response,ExpectedCode);
+                await verifyResponseSchema(response,schema);
+            },
+
+            searchProduct: async (method, ExpectedCode, ExpectedMessage, productName) => {
+                let schema;
+                if(ExpectedCode !== Status.success){
+                    schema = z.object({
+                        responseCode: z.literal(ExpectedCode),
+                        message: z.literal(ExpectedMessage)
+                    });
+                }else{
+                    schema = z.object({
+                        responseCode: z.literal(ExpectedCode),
+                        products: z.array(
+                            z.object({
+                                id: z.number(),
+                                name: z.string(),
+                                price: z.string(),
+                                brand: z.string(),
+                                category: z.object({
+                                    usertype: z.object({
+                                        usertype: z.string()
+                                    }),
+                                    category: z.string()
+                                })
+                            })
+                        )
+                    });
+                } 
+                const response = await this.requests.POST_searchProduct(method,productName);
+                await verifyResponseCode(response,ExpectedCode);
+                await verifyResponseSchema(response,schema);
+            },
+        };
     }
 }

--- a/API/Products.ts
+++ b/API/Products.ts
@@ -1,6 +1,5 @@
 import { APIRequestContext, APIResponse,expect } from '@playwright/test';
-import { verifyResponseSchema, verifyResponseCode } from '../Helper/Tools';
-import { makeRequest, buildSchema } from '../Helper/API_Helper';
+import { makeRequest, buildSchema, verifyResponseSchema, verifyResponseCode } from '../Helper/API_Helper';
 import { z } from 'zod';
 import { APIEndPoints, Status } from '../Helper/API_Helper';
 

--- a/Helper/API_Helper.ts
+++ b/Helper/API_Helper.ts
@@ -22,3 +22,5 @@ export const Messages = {
     emailAlreadyExistsMessage: "Email already exists!",
     methodNotAllowedMessage: (method: string) => `Method \"${method}\" not allowed.`,
 }
+
+export const Titles = {Mr: "Mr", Mrs: "Mrs", Miss: "Miss"};

--- a/Helper/API_Helper.ts
+++ b/Helper/API_Helper.ts
@@ -27,6 +27,20 @@ export async function makeRequest(request: APIRequestContext, url: string, metho
   }
 }
 
+export async function verifyResponseCode(response: APIResponse, expectedCode: Number){
+  const responseBody = await response.json();
+  //console.log(responseBody);
+  await expect(responseBody.responseCode,`Expected: ${expectedCode}\nReceived: ${responseBody.responseCode}\nFull response: ${JSON.stringify(responseBody, null, 2)}`).toBe(expectedCode);
+  await expect((await response).ok()).toBeTruthy();
+}
+
+export async function verifyResponseSchema(response: APIResponse, schema: z.ZodTypeAny){ {
+  const responseBody = await response.json();
+  expect(() => {
+    schema.parse(responseBody);
+  }).not.toThrow();
+}}
+
 export const APIEndPoints = {
     verifyLogin: '/api/verifyLogin',
     createAccount: '/api/createAccount',

--- a/Helper/API_Helper.ts
+++ b/Helper/API_Helper.ts
@@ -1,3 +1,32 @@
+import { expect, type APIRequestContext, type APIResponse } from "@playwright/test";
+import { z } from 'zod';
+
+export async function buildSchema(successSchema: z.ZodTypeAny, ExpectedCode: number, ExpectedMessage?: string) {
+    if (ExpectedCode !== Status.success) {
+        return z.object({
+            responseCode: z.literal(ExpectedCode),
+            message: z.literal(ExpectedMessage)
+        });
+    }
+    return successSchema;
+}
+
+export async function makeRequest(request: APIRequestContext, url: string, method: string, form: Record<string, string> = {}): Promise<APIResponse> {
+  expect(method).not.toBe(undefined);
+  switch (method) {
+    case 'POST':
+      return request.post(url, { form });
+    case 'GET':
+      return request.get(url, {  params: form });
+    case 'PUT':
+      return request.put(url, { form });
+    case 'DELETE':
+      return request.delete(url, { form });
+    default:
+      throw new Error(`Unsupported method: ${method}`);
+  }
+}
+
 export const APIEndPoints = {
     verifyLogin: '/api/verifyLogin',
     createAccount: '/api/createAccount',

--- a/Helper/Fixtures.ts
+++ b/Helper/Fixtures.ts
@@ -11,7 +11,7 @@ import { ProductsPage } from '../Pages/ProductsPage';
 import { ProductPage } from '../Pages/ProductPage';
 import { CartPage } from '../Pages/CartPage';
 import { PaymentPage } from '../Pages/PaymentPage';
-import { AuthorizationAPI } from '../API/Authorization';
+import { AuthorizationAPI } from '../API/Authorization.ts';
 import { ProductsAPI } from '../API/Products.ts';
 import { blockAds, saveAdditionsAttachments } from './Tools.ts';
 import dotenv from 'dotenv';

--- a/Helper/Tools.ts
+++ b/Helper/Tools.ts
@@ -27,21 +27,6 @@ export async function emptyDir(dir: string) {
   }
 }
 
-export async function makeRequest(request: APIRequestContext, url: string, method: string, form: Record<string, string> = {}): Promise<APIResponse> {
-  switch (method) {
-    case 'POST':
-      return request.post(url, { form });
-    case 'GET':
-      return request.get(url, {  params: form });
-    case 'PUT':
-      return request.put(url, { form });
-    case 'DELETE':
-      return request.delete(url, { form });
-    default:
-      throw new Error(`Unsupported method: ${method}`);
-  }
-}
-
 export async function verifyResponseCode(response: APIResponse, expectedCode: Number){
   const responseBody = await response.json();
   //console.log(responseBody);

--- a/Helper/Tools.ts
+++ b/Helper/Tools.ts
@@ -1,4 +1,4 @@
-import { expect, type APIRequestContext, type APIResponse, type BrowserContext } from "@playwright/test";
+import { expect, type APIResponse, type BrowserContext } from "@playwright/test";
 import fs from 'fs/promises';
 import { z } from 'zod';
 
@@ -26,20 +26,6 @@ export async function emptyDir(dir: string) {
     // Ignore errors
   }
 }
-
-export async function verifyResponseCode(response: APIResponse, expectedCode: Number){
-  const responseBody = await response.json();
-  //console.log(responseBody);
-  await expect(responseBody.responseCode,`Expected: ${expectedCode}\nReceived: ${responseBody.responseCode}\nFull response: ${JSON.stringify(responseBody, null, 2)}`).toBe(expectedCode);
-  await expect((await response).ok()).toBeTruthy();
-}
-
-export async function verifyResponseSchema(response: APIResponse, schema: z.ZodTypeAny){ {
-  const responseBody = await response.json();
-  expect(() => {
-    schema.parse(responseBody);
-  }).not.toThrow();
-}}
 
 export async function getEnv(name: string): Promise<string> {
   const value = process.env[name];

--- a/tests/API/Authorization.api.spec.js
+++ b/tests/API/Authorization.api.spec.js
@@ -4,67 +4,67 @@ import { generateRandomEmail, getEnv } from '../../Helper/Tools';
 
 test.describe("API Authorization tests", () => {
     test('C8 POST (/api/verifyLogin) User exists with valid credentials', async({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.success,Messages.userFoundMessage, await getEnv("VALID_LOGIN_EMAIL"),await getEnv("VALID_LOGIN_PASSWORD"));
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.success,Messages.userFoundMessage, await getEnv("VALID_LOGIN_EMAIL"),await getEnv("VALID_LOGIN_PASSWORD"));
     });
 
     test('C4 POST (/api/verifyLogin) User does not exist (valid format but not registered)', async ({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,(await generateRandomEmail()),await getEnv("REGISTER_PASSWORD"));
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,(await generateRandomEmail()),await getEnv("REGISTER_PASSWORD"));
     });
 
     test('C1 POST (/api/verifyLogin) Invalid email format', async ({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,"invalid-email",await getEnv("VALID_LOGIN_PASSWORD"));
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,"invalid-email",await getEnv("VALID_LOGIN_PASSWORD"));
     });
 
     test('C3 POST (/api/verifyLogin) Empty email field', async ({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,"",await getEnv("VALID_LOGIN_PASSWORD"));
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,"",await getEnv("VALID_LOGIN_PASSWORD"));
     });
 
     test('C5 POST (/api/verifyLogin) Empty password field', async ({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,await getEnv("VALID_LOGIN_EMAIL"),"");
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,await getEnv("VALID_LOGIN_EMAIL"),"");
     });  
 
     test('C2 POST (/api/verifyLogin) Both email and password missing', async ({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,"","");
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,"","");
     });
 
     test('C7 POST (/api/verifyLogin) Case sensitivity check email', async ({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,(await getEnv("VALID_LOGIN_EMAIL")).toUpperCase(),await getEnv("VALID_LOGIN_PASSWORD"));
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,(await getEnv("VALID_LOGIN_EMAIL")).toUpperCase(),await getEnv("VALID_LOGIN_PASSWORD"));
     });
 
     test('C10 POST (/api/verifyLogin) Case sensitivity check password', async ({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,await getEnv("VALID_LOGIN_EMAIL"),(await getEnv("VALID_LOGIN_PASSWORD")).toUpperCase());
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,await getEnv("VALID_LOGIN_EMAIL"),(await getEnv("VALID_LOGIN_PASSWORD")).toUpperCase());
     });
 
     test('C9 POST (/api/verifyLogin) SQL Injection in email', async ({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,await getEnv("VALID_LOGIN_EMAIL") + "' OR '1'='1",await getEnv("VALID_LOGIN_PASSWORD"));
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,await getEnv("VALID_LOGIN_EMAIL") + "' OR '1'='1",await getEnv("VALID_LOGIN_PASSWORD"));
     });
 
     test('C6 POST (/api/verifyLogin) SQL Injection in password', async ({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,await getEnv("VALID_LOGIN_EMAIL"),await getEnv("VALID_LOGIN_PASSWORD") + "' OR '1'='1");
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,await getEnv("VALID_LOGIN_EMAIL"),await getEnv("VALID_LOGIN_PASSWORD") + "' OR '1'='1");
     });
 
     test('C11 POST (/api/verifyLogin) Very long input fields', async ({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,(await getEnv("VALID_LOGIN_EMAIL")).repeat(400),(await getEnv("VALID_LOGIN_PASSWORD")).repeat(400));
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.notFound,Messages.userNotFoundMessage,(await getEnv("VALID_LOGIN_EMAIL")).repeat(400),(await getEnv("VALID_LOGIN_PASSWORD")).repeat(400));
     });
 
     test('C12 POST (/api/verifyLogin) No email key', async ({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.badReq,Messages.badRequestMessage(Methods.POST),undefined,await getEnv("VALID_LOGIN_PASSWORD"));
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.badReq,Messages.badRequestMessage(Methods.POST),undefined,await getEnv("VALID_LOGIN_PASSWORD"));
     });
 
     test('C13 POST (/api/verifyLogin) No password key', async ({ authorizationAPI }) => {
-        await authorizationAPI.verifyLogin(Methods.POST,Status.badReq,Messages.badRequestMessage(Methods.POST),await getEnv("VALID_LOGIN_EMAIL"),undefined);
+        await authorizationAPI.methods.verifyLogin(Methods.POST,Status.badReq,Messages.badRequestMessage(Methods.POST),await getEnv("VALID_LOGIN_EMAIL"),undefined);
     });
 
     test('C18 GET, PUT, DELETE (/api/verifyLogin) Incorrect req method', async ({ authorizationAPI }) => {
         for (const method of Object.values(Methods)) {
             if (method === 'POST') continue; // skip POST (correct req method)
-            await authorizationAPI.verifyLogin(method,Status.methodNotAllowed,Messages.notSupportedReqMethodMessage,await getEnv("VALID_LOGIN_EMAIL"),await getEnv("VALID_LOGIN_PASSWORD"));
+            await authorizationAPI.methods.verifyLogin(method,Status.methodNotAllowed,Messages.notSupportedReqMethodMessage,await getEnv("VALID_LOGIN_EMAIL"),await getEnv("VALID_LOGIN_PASSWORD"));
         }
     });
     
     test('C15 POST (/api/createAccount) Successful registration with valid data', async ({ authorizationAPI }) => {
         const email = await generateRandomEmail();
-        await authorizationAPI.createAccount(
+        await authorizationAPI.methods.createAccount(
             Methods.POST,
             Status.resourceCreated,
             Messages.userCreatedMessage,
@@ -88,12 +88,12 @@ test.describe("API Authorization tests", () => {
         );
 
         //Delete account
-        await authorizationAPI.deleteAccount(Methods.DELETE,email,await getEnv("REGISTER_PASSWORD"),Status.success,Messages.userDeletedMessage);
+        await authorizationAPI.methods.deleteAccount(Methods.DELETE,email,await getEnv("REGISTER_PASSWORD"),Status.success,Messages.userDeletedMessage);
     });
 
     test('C16 POST (/api/createAccount) Bad req registration with only email and password', async ({ authorizationAPI }) => {
         const email = await generateRandomEmail();
-        await authorizationAPI.createAccount(
+        await authorizationAPI.methods.createAccount(
              Methods.POST,
              Status.badReq,
              Messages.badRequestParameterMessage(Methods.POST,"name"),
@@ -105,7 +105,7 @@ test.describe("API Authorization tests", () => {
 
     test('C17 POST (/api/createAccount) Success registration with only email and password', async ({ authorizationAPI }) => {
         const email = await generateRandomEmail();
-        await authorizationAPI.createAccount(
+        await authorizationAPI.methods.createAccount(
              Methods.POST,
              Status.resourceCreated,
              Messages.userCreatedMessage,
@@ -129,11 +129,11 @@ test.describe("API Authorization tests", () => {
         );
 
         //Delete account
-        await authorizationAPI.deleteAccount(Methods.DELETE,email,await getEnv("REGISTER_PASSWORD"),Status.success,Messages.userDeletedMessage);
+        await authorizationAPI.methods.deleteAccount(Methods.DELETE,email,await getEnv("REGISTER_PASSWORD"),Status.success,Messages.userDeletedMessage);
     });
 
     test('C19 POST (/api/createAccount) Duplicate email registration', async ({ authorizationAPI }) => {
-        await authorizationAPI.createAccount(
+        await authorizationAPI.methods.createAccount(
              Methods.POST,
              Status.badReq,
              Messages.emailAlreadyExistsMessage,
@@ -161,7 +161,7 @@ test.describe("API Authorization tests", () => {
         for (const method of Object.values(Methods)) {
             if (method === 'POST') continue; // skip POST (correct req method)
             const email = await generateRandomEmail();
-            await authorizationAPI.createAccount(
+            await authorizationAPI.methods.createAccount(
                 method,
                 Status.methodNotAllowed,
                 Messages.methodNotAllowedMessage(method),
@@ -187,25 +187,25 @@ test.describe("API Authorization tests", () => {
     });
 
     test('C20 GET (/api/getUserDetailByEmail) Valid request with existing user email', async ({ authorizationAPI }) => {
-        await authorizationAPI.getUserDetailByEmail(Methods.GET,await getEnv("VALID_LOGIN_EMAIL"),Status.success);
+        await authorizationAPI.methods.getUserDetailByEmail(Methods.GET,await getEnv("VALID_LOGIN_EMAIL"),Status.success);
     });
 
     test('C21 GET (/api/getUserDetailByEmail) Valid request with not existing user email', async ({ authorizationAPI }) => {
-        await authorizationAPI.getUserDetailByEmail(Methods.GET,(await getEnv("VALID_LOGIN_EMAIL") + "1"),Status.notFound,Messages.accountNotFoundMessage);
+        await authorizationAPI.methods.getUserDetailByEmail(Methods.GET,(await getEnv("VALID_LOGIN_EMAIL") + "1"),Status.notFound,Messages.accountNotFoundMessage);
     });
 
     test('C23 GET (/api/getUserDetailByEmail) Case-insensitive email match', async ({ authorizationAPI }) => {
-        await authorizationAPI.getUserDetailByEmail(Methods.GET,(await getEnv("VALID_LOGIN_EMAIL")).toUpperCase(),Status.notFound,Messages.accountNotFoundMessage);
+        await authorizationAPI.methods.getUserDetailByEmail(Methods.GET,(await getEnv("VALID_LOGIN_EMAIL")).toUpperCase(),Status.notFound,Messages.accountNotFoundMessage);
     });
 
     test('C22 GET (/api/getUserDetailByEmail) Missing email parameter', async ({ authorizationAPI }) => {
-        await authorizationAPI.getUserDetailByEmail(Methods.GET,undefined,Status.badReq,Messages.badRequestParameterMessage(Methods.GET,"email"));
+        await authorizationAPI.methods.getUserDetailByEmail(Methods.GET,undefined,Status.badReq,Messages.badRequestParameterMessage(Methods.GET,"email"));
     });
 
     test('C24 POST, PUT, DELETE (/api/getUserDetailByEmail) Incorrect req method', async ({ authorizationAPI }) => {
         for (const method of Object.values(Methods)) {
             if (method === 'GET') continue; // skip POST (correct req method)
-            await authorizationAPI.getUserDetailByEmail(method,await getEnv("VALID_LOGIN_EMAIL"),Status.methodNotAllowed,Messages.notSupportedReqMethodMessage)
+            await authorizationAPI.methods.getUserDetailByEmail(method,await getEnv("VALID_LOGIN_EMAIL"),Status.methodNotAllowed,Messages.notSupportedReqMethodMessage)
         }
     });
 });

--- a/tests/API/Products.api.spec.ts
+++ b/tests/API/Products.api.spec.ts
@@ -3,35 +3,35 @@ import { Methods, Status, Messages } from '../../Helper/API_Helper.ts';
 
 test.describe("API Product & Catalog tests", () => {
     test('C28 GET /api/brandsList returns valid brand list', async ({ productsAPI }) => {
-        await productsAPI.brandsList(Methods.GET,Status.success);
+        await productsAPI.methods.brandsList(Methods.GET,Status.success);
     });
 
     test('C27 POST, PUT, DELETE (/api/brandsList) Incorrect req method', async({ productsAPI }) => {
         for (const method of Object.values(Methods)) {
             if(method === "GET") continue;
-            await productsAPI.brandsList(method,Status.methodNotAllowed,Messages.notSupportedReqMethodMessage);
+            await productsAPI.methods.brandsList(method,Status.methodNotAllowed,Messages.notSupportedReqMethodMessage);
         }
     });
 
     test('C25 POST /api/searchProduct returns products for valid keywords', async ({ productsAPI }) => {
         const productsNames = ["dress","top","tshirt"]; //keyWords
         for(const productsName of productsNames){
-            await productsAPI.searchProduct(Methods.POST,Status.success,"",productsName);
+            await productsAPI.methods.searchProduct(Methods.POST,Status.success,"",productsName);
         }
     });
 
     test('C26 GET, PUT, DELETE (/api/searchProduct) Incorrect req method', async({ productsAPI }) => {
         for (const method of Object.values(Methods)) {
             if(method === "POST") continue;
-            await productsAPI.searchProduct(method,Status.methodNotAllowed,Messages.notSupportedReqMethodMessage,"top");
+            await productsAPI.methods.searchProduct(method,Status.methodNotAllowed,Messages.notSupportedReqMethodMessage,"top");
         }
     });
 
     test('C29 POST /api/searchProduct returns empty result for non-existent product', async ({ productsAPI }) => {
-        await productsAPI.searchProduct(Methods.POST,Status.success,"","top1231");
+        await productsAPI.methods.searchProduct(Methods.POST,Status.success,"","top1231");
     });
 
     test('C30 POST /api/searchProduct returns 400 Bad Request when keyword is missing', async ({ productsAPI }) => {
-        await productsAPI.searchProduct(Methods.POST,Status.badReq,Messages.badRequestParameterMessage(Methods.POST,"search_product"),"");
+        await productsAPI.methods.searchProduct(Methods.POST,Status.badReq,Messages.badRequestParameterMessage(Methods.POST,"search_product"),"");
     });
 });

--- a/tests/E2E/Checkout_Flow.spec.ts
+++ b/tests/E2E/Checkout_Flow.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '../../Helper/Fixtures.ts';
-import { Methods } from '../../Helper/API_Helper.ts';
+import { Methods, Status, Messages } from '../../Helper/API_Helper.ts';
 import { generateRandomEmail, getEnv } from '../../Helper/Tools.ts';
 
 test.describe("E2E Checkout Flow", () => {
@@ -51,8 +51,10 @@ test.describe("E2E Checkout Flow", () => {
     await cartPage.actions.clickRegisterAndLoginButton();
 
     //Fill signup form
-    await authorizationAPI.POST_createAccount(
+    await authorizationAPI.methods.createAccount(
       Methods.POST,
+      Status.resourceCreated,
+      Messages.userCreatedMessage,
       await getEnv("REGISTER_NAME_FIRST"),
       email,
       await getEnv("REGISTER_PASSWORD"),
@@ -173,8 +175,10 @@ test.describe("E2E Checkout Flow", () => {
     const email = await generateRandomEmail();
     let authorized = false;
 
-    await authorizationAPI.POST_createAccount(
+    await authorizationAPI.methods.createAccount(
       Methods.POST,
+      Status.resourceCreated,
+      Messages.userCreatedMessage,
       await getEnv("REGISTER_NAME_FIRST"),
       email,
       await getEnv("REGISTER_PASSWORD"),


### PR DESCRIPTION
1. API Architecture Improvements

Added `requests`, `assertions`, and `methods `sections to both `AuthorizationAPI `and `ProductsAPI`, allowing calls like:

`authorizationAPI.requests.POST_createAccount(...)`

`authorizationAPI.methods.verifyLogin(...)`

Converted `schemas`, `request`, and `requests `to private

Implemented centralized schemas inside the API class for cleaner maintainability.

<img width="1930" height="695" alt="Screenshot_17" src="https://github.com/user-attachments/assets/504b8c0c-749c-4b74-90be-2a51f69fc428" />

2. Helper & Utility Refactoring

Moved [makeRequest](https://github.com/NGon001/playwright-automation-exercise/blob/main/Helper/API_Helper.ts#L14-L28) to API_Helper.ts.

Added new [buildSchema](https://github.com/NGon001/playwright-automation-exercise/blob/main/Helper/API_Helper.ts#L4-L12) function to unify schema generation logic.

Moved verifyResponseSchema and verifyResponseCode to `API_Helper.ts.`

`API_Helpers.ts` now includes "Titles".

<img width="1921" height="790" alt="Screenshot_18" src="https://github.com/user-attachments/assets/f4abc951-d2ca-4efb-b5c1-3175a7521666" />


3. Minor Fixes

Moved `expect(method).not.toBe(undefined);` into makeRequest to avoid duplication.